### PR TITLE
better button enum

### DIFF
--- a/include/minigamepad.h
+++ b/include/minigamepad.h
@@ -14,50 +14,35 @@ typedef struct mg_gamepads_t mg_gamepads;
 /// A button on a gamepad
 typedef enum {
   MG_GAMEPAD_BUTTON_UNKNOWN = 0,
-  MG_GAMEPAD_BUTTON_0,
-  MG_GAMEPAD_BUTTON_1,
-  MG_GAMEPAD_BUTTON_2,
-  MG_GAMEPAD_BUTTON_3,
-  MG_GAMEPAD_BUTTON_4,
-  MG_GAMEPAD_BUTTON_5,
-  MG_GAMEPAD_BUTTON_6,
-  MG_GAMEPAD_BUTTON_7,
-  MG_GAMEPAD_BUTTON_8,
-  MG_GAMEPAD_BUTTON_9,
-  // A Button on an Xbox One Controller
-  MG_GAMEPAD_BUTTON_10,
-  // x Button on an Xbox One Controller
-  MG_GAMEPAD_BUTTON_11,
-  // Y Button on an Xbox One Controller
-  MG_GAMEPAD_BUTTON_12,
-  // B Button on an Xbox One Controller
-  MG_GAMEPAD_BUTTON_13,
-  MG_GAMEPAD_BUTTON_JOYSTICK,
-  MG_GAMEPAD_BUTTON_THUMB,
-  MG_GAMEPAD_BUTTON_THUMB2,
-  MG_GAMEPAD_BUTTON_TOP,
-  MG_GAMEPAD_BUTTON_TOP2,
-  MG_GAMEPAD_BUTTON_PINKIE,
-  MG_GAMEPAD_BUTTON_BASE,
-  MG_GAMEPAD_BUTTON_BASE2,
-  MG_GAMEPAD_BUTTON_BASE3,
-  MG_GAMEPAD_BUTTON_BASE4,
-  MG_GAMEPAD_BUTTON_BASE5,
-  MG_GAMEPAD_BUTTON_BASE6,
-  MG_GAMEPAD_BUTTON_DEAD,
-  MG_GAMEPAD_BUTTON_C,
-  MG_GAMEPAD_BUTTON_Z,
-  MG_GAMEPAD_BUTTON_TL,
-  MG_GAMEPAD_BUTTON_TR,
-  MG_GAMEPAD_BUTTON_TL2,
-  MG_GAMEPAD_BUTTON_TR2,
-  MG_GAMEPAD_BUTTON_SELECT,
+  MG_GAMEPAD_BUTTON_SOUTH, /**< Bottom face button (e.g. Xbox A button) */
+  MG_GAMEPAD_BUTTON_WEST,  /**< Left face button (e.g. Xbox X button) */
+  MG_GAMEPAD_BUTTON_NORTH, /**< Top face button (e.g. Xbox Y button) */
+  MG_GAMEPAD_BUTTON_EAST,  /**< Right face button (e.g. Xbox B button) */
+  MG_GAMEPAD_BUTTON_BACK,
+  MG_GAMEPAD_BUTTON_GUIDE,
   MG_GAMEPAD_BUTTON_START,
-  MG_GAMEPAD_BUTTON_MODE,
-  MG_GAMEPAD_BUTTON_THUMBL,
-  MG_GAMEPAD_BUTTON_THUMBR,
-  MG_GAMEPAD_BUTTON_DIGI,
-
+  MG_GAMEPAD_BUTTON_LEFT_STICK,
+  MG_GAMEPAD_BUTTON_RIGHT_STICK,
+  MG_GAMEPAD_BUTTON_LEFT_SHOULDER,
+  MG_GAMEPAD_BUTTON_RIGHT_SHOULDER,
+  MG_GAMEPAD_BUTTON_MISC1, /**< Additional button (e.g. Xbox Series X share
+                               button, PS5 microphone button, Nintendo Switch
+                               Pro capture button, Amazon Luna microphone
+                               button, Google Stadia capture button) */
+  MG_GAMEPAD_BUTTON_RIGHT_PADDLE1, /**< Upper or primary paddle, under your
+                                       right hand (e.g. Xbox Elite paddle P1) */
+  MG_GAMEPAD_BUTTON_LEFT_PADDLE1,  /**< Upper or primary paddle, under your left
+                                       hand (e.g. Xbox Elite paddle P3) */
+  MG_GAMEPAD_BUTTON_RIGHT_PADDLE2, /**< Lower or secondary paddle, under your
+                                       right hand (e.g. Xbox Elite paddle P2) */
+  MG_GAMEPAD_BUTTON_LEFT_PADDLE2,  /**< Lower or secondary paddle, under your
+                                       left hand (e.g. Xbox Elite paddle P4) */
+  MG_GAMEPAD_BUTTON_TOUCHPAD,      /**< PS4/PS5 touchpad button */
+  MG_GAMEPAD_BUTTON_MISC2,         /**< Additional button */
+  MG_GAMEPAD_BUTTON_MISC3,         /**< Additional button */
+  MG_GAMEPAD_BUTTON_MISC4,         /**< Additional button */
+  MG_GAMEPAD_BUTTON_MISC5,         /**< Additional button */
+  MG_GAMEPAD_BUTTON_MISC6,         /**< Additional button */
   MG_GAMEPAD_BUTTON_MAX
 } mg_gamepad_btn;
 

--- a/src/common/gamepad_name_map.c
+++ b/src/common/gamepad_name_map.c
@@ -2,86 +2,53 @@
 
 const char *mg_gamepad_btn_get_name(mg_gamepad_btn btn) {
   switch (btn) {
+  case MG_GAMEPAD_BUTTON_MAX:
   case MG_GAMEPAD_BUTTON_UNKNOWN:
-  case MG_GAMEPAD_BUTTON_0:
-    return "Button 0";
-  case MG_GAMEPAD_BUTTON_1:
-    return "Button 1";
-  case MG_GAMEPAD_BUTTON_2:
-    return "Button 2";
-  case MG_GAMEPAD_BUTTON_3:
-    return "Button 3";
-  case MG_GAMEPAD_BUTTON_4:
-    return "Button 4";
-  case MG_GAMEPAD_BUTTON_5:
-    return "Button 5";
-  case MG_GAMEPAD_BUTTON_6:
-    return "Button 6";
-  case MG_GAMEPAD_BUTTON_7:
-    return "Button 7";
-  case MG_GAMEPAD_BUTTON_8:
-    return "Button 8";
-  case MG_GAMEPAD_BUTTON_9:
-    return "Button 9";
-  case MG_GAMEPAD_BUTTON_10:
-    return "Button 10";
-  case MG_GAMEPAD_BUTTON_11:
-    return "Button 11";
-  case MG_GAMEPAD_BUTTON_12:
-    return "Button 12";
-  case MG_GAMEPAD_BUTTON_13:
-    return "Button 13";
-  case MG_GAMEPAD_BUTTON_JOYSTICK:
-    return "Joystick Button";
-  case MG_GAMEPAD_BUTTON_THUMB:
-    return "Thumb Button";
-  case MG_GAMEPAD_BUTTON_THUMB2:
-    return "Thumb Button 2";
-  case MG_GAMEPAD_BUTTON_TOP:
-    return "Top Button";
-  case MG_GAMEPAD_BUTTON_TOP2:
-    return "Top Button 2";
-  case MG_GAMEPAD_BUTTON_PINKIE:
-    return "Pinkie Button";
-  case MG_GAMEPAD_BUTTON_BASE:
-    return "Base Button 1";
-  case MG_GAMEPAD_BUTTON_BASE2:
-    return "Base Button 2";
-  case MG_GAMEPAD_BUTTON_BASE3:
-    return "Base Button 3";
-  case MG_GAMEPAD_BUTTON_BASE4:
-    return "Base Button 4";
-  case MG_GAMEPAD_BUTTON_BASE5:
-    return "Base Button 5";
-  case MG_GAMEPAD_BUTTON_BASE6:
-    return "Base Button 6";
-  case MG_GAMEPAD_BUTTON_DEAD:
-    return "Dead Button";
-  case MG_GAMEPAD_BUTTON_C:
-    return "Button C";
-
-  case MG_GAMEPAD_BUTTON_Z:
-    return "Z Button";
-  case MG_GAMEPAD_BUTTON_TL:
-    return "TL Button";
-  case MG_GAMEPAD_BUTTON_TR:
-    return "TR Button";
-  case MG_GAMEPAD_BUTTON_TL2:
-    return "TL2 Button";
-  case MG_GAMEPAD_BUTTON_TR2:
-    return "TR2 Button";
-  case MG_GAMEPAD_BUTTON_SELECT:
-    return "Select Button";
+    return "Unknown Button";
+  case MG_GAMEPAD_BUTTON_SOUTH:
+    return "South Button";
+  case MG_GAMEPAD_BUTTON_WEST:
+    return "West Button";
+  case MG_GAMEPAD_BUTTON_NORTH:
+    return "North Button";
+  case MG_GAMEPAD_BUTTON_EAST:
+    return "East Button";
+  case MG_GAMEPAD_BUTTON_BACK:
+    return "Back Button";
+  case MG_GAMEPAD_BUTTON_GUIDE:
+    return "Guide Button";
   case MG_GAMEPAD_BUTTON_START:
     return "Start Button";
-  case MG_GAMEPAD_BUTTON_MODE:
-    return "Mode Button";
-  case MG_GAMEPAD_BUTTON_THUMBL:
-    return "Thumb Button L";
-  case MG_GAMEPAD_BUTTON_THUMBR:
-    return "Thumb Button R";
-  case MG_GAMEPAD_BUTTON_DIGI:
-    return "DIGI Button";
+  case MG_GAMEPAD_BUTTON_LEFT_STICK:
+    return "Left Stick Button";
+  case MG_GAMEPAD_BUTTON_RIGHT_STICK:
+    return "Right Stick Button";
+  case MG_GAMEPAD_BUTTON_LEFT_SHOULDER:
+    return "Left Shoulder Button";
+  case MG_GAMEPAD_BUTTON_RIGHT_SHOULDER:
+    return "Right Shoulder Button";
+  case MG_GAMEPAD_BUTTON_MISC1:
+    return "Misc Button 1";
+  case MG_GAMEPAD_BUTTON_RIGHT_PADDLE1:
+    return "Paddle 1 Right";
+  case MG_GAMEPAD_BUTTON_LEFT_PADDLE1:
+    return "Paddle 1 Left";
+  case MG_GAMEPAD_BUTTON_RIGHT_PADDLE2:
+    return "Paddle 2 Right";
+  case MG_GAMEPAD_BUTTON_LEFT_PADDLE2:
+    return "Paddle 2 Left";
+  case MG_GAMEPAD_BUTTON_TOUCHPAD:
+    return "Touchpad";
+  case MG_GAMEPAD_BUTTON_MISC2:
+    return "Misc Button 2";
+  case MG_GAMEPAD_BUTTON_MISC3:
+    return "Misc Button 3";
+  case MG_GAMEPAD_BUTTON_MISC4:
+    return "Misc Button 4";
+  case MG_GAMEPAD_BUTTON_MISC5:
+    return "Misc Button 5";
+  case MG_GAMEPAD_BUTTON_MISC6:
+    return "Misc Button 6";
   }
   return NULL;
 };

--- a/src/linux/gamepad_btn_conv.c
+++ b/src/linux/gamepad_btn_conv.c
@@ -4,84 +4,52 @@
 
 mg_gamepad_btn get_gamepad_btn(int btn) {
   switch (btn) {
-  case BTN_0:
-    return MG_GAMEPAD_BUTTON_0;
-  case BTN_1:
-    return MG_GAMEPAD_BUTTON_1;
-  case BTN_2:
-    return MG_GAMEPAD_BUTTON_2;
-  case BTN_3:
-    return MG_GAMEPAD_BUTTON_3;
-  case BTN_4:
-    return MG_GAMEPAD_BUTTON_4;
-  case BTN_5:
-    return MG_GAMEPAD_BUTTON_5;
-  case BTN_6:
-    return MG_GAMEPAD_BUTTON_6;
-  case BTN_7:
-    return MG_GAMEPAD_BUTTON_7;
-  case BTN_8:
-    return MG_GAMEPAD_BUTTON_8;
-  case BTN_9:
-    return MG_GAMEPAD_BUTTON_9;
-  case BTN_SOUTH:
-    return MG_GAMEPAD_BUTTON_10;
-  case BTN_NORTH:
-    return MG_GAMEPAD_BUTTON_11;
   case BTN_WEST:
-    return MG_GAMEPAD_BUTTON_12;
+    return MG_GAMEPAD_BUTTON_WEST;
+  case BTN_A:
+    return MG_GAMEPAD_BUTTON_SOUTH;
+  case BTN_NORTH:
+    return MG_GAMEPAD_BUTTON_NORTH;
   case BTN_EAST:
-    return MG_GAMEPAD_BUTTON_13;
-  case BTN_JOYSTICK:
-    return MG_GAMEPAD_BUTTON_JOYSTICK;
-  case BTN_THUMB:
-    return MG_GAMEPAD_BUTTON_THUMB;
-  case BTN_THUMB2:
-    return MG_GAMEPAD_BUTTON_THUMB2;
-  case BTN_TOP:
-    return MG_GAMEPAD_BUTTON_TOP;
-  case BTN_TOP2:
-    return MG_GAMEPAD_BUTTON_TOP2;
-  case BTN_PINKIE:
-    return MG_GAMEPAD_BUTTON_PINKIE;
-  case BTN_BASE:
-    return MG_GAMEPAD_BUTTON_BASE;
-  case BTN_BASE2:
-    return MG_GAMEPAD_BUTTON_BASE2;
-  case BTN_BASE3:
-    return MG_GAMEPAD_BUTTON_BASE3;
-  case BTN_BASE4:
-    return MG_GAMEPAD_BUTTON_BASE4;
-  case BTN_BASE5:
-    return MG_GAMEPAD_BUTTON_BASE5;
-  case BTN_BASE6:
-    return MG_GAMEPAD_BUTTON_BASE6;
-  case BTN_DEAD:
-    return MG_GAMEPAD_BUTTON_DEAD;
-  case BTN_C:
-    return MG_GAMEPAD_BUTTON_C;
-  case BTN_Z:
-    return MG_GAMEPAD_BUTTON_Z;
-  case BTN_TL:
-    return MG_GAMEPAD_BUTTON_TL;
-  case BTN_TR:
-    return MG_GAMEPAD_BUTTON_TR;
-  case BTN_TL2:
-    return MG_GAMEPAD_BUTTON_TL2;
-  case BTN_TR2:
-    return MG_GAMEPAD_BUTTON_TR2;
-  case BTN_SELECT:
-    return MG_GAMEPAD_BUTTON_SELECT;
+    return MG_GAMEPAD_BUTTON_EAST;
+  case BTN_BACK:
+    return MG_GAMEPAD_BUTTON_BACK;
+  case BTN_MODE:
+    return MG_GAMEPAD_BUTTON_GUIDE;
   case BTN_START:
     return MG_GAMEPAD_BUTTON_START;
-  case BTN_MODE:
-    return MG_GAMEPAD_BUTTON_MODE;
   case BTN_THUMBL:
-    return MG_GAMEPAD_BUTTON_THUMBL;
+    return MG_GAMEPAD_BUTTON_LEFT_STICK;
   case BTN_THUMBR:
-    return MG_GAMEPAD_BUTTON_THUMBR;
-  case BTN_DIGI:
-    return MG_GAMEPAD_BUTTON_DIGI;
+    return MG_GAMEPAD_BUTTON_RIGHT_STICK;
+  case BTN_TL:
+    return MG_GAMEPAD_BUTTON_LEFT_SHOULDER;
+  case BTN_TR:
+    return MG_GAMEPAD_BUTTON_RIGHT_SHOULDER;
+  case BTN_TOUCH:
+    return MG_GAMEPAD_BUTTON_TOUCHPAD;
+  case BTN_TRIGGER_HAPPY5:
+    return MG_GAMEPAD_BUTTON_RIGHT_PADDLE1;
+  case BTN_TRIGGER_HAPPY6:
+    return MG_GAMEPAD_BUTTON_RIGHT_PADDLE2;
+  case BTN_TRIGGER_HAPPY7:
+    return MG_GAMEPAD_BUTTON_LEFT_PADDLE1;
+  case BTN_TRIGGER_HAPPY8:
+    return MG_GAMEPAD_BUTTON_LEFT_PADDLE2;
+
+  case BTN_SELECT:
+    return MG_GAMEPAD_BUTTON_MISC1;
+  case BTN_TRIGGER_HAPPY2:
+    return MG_GAMEPAD_BUTTON_MISC2;
+  case BTN_TRIGGER_HAPPY3:
+    return MG_GAMEPAD_BUTTON_MISC3;
+  case BTN_TRIGGER_HAPPY4:
+    return MG_GAMEPAD_BUTTON_MISC4;
+  case BTN_TRIGGER_HAPPY9:
+    return MG_GAMEPAD_BUTTON_MISC5;
+  case BTN_TRIGGER_HAPPY10:
+    return MG_GAMEPAD_BUTTON_MISC6;
+
   default:
     return MG_GAMEPAD_BUTTON_UNKNOWN;
   }
@@ -89,85 +57,46 @@ mg_gamepad_btn get_gamepad_btn(int btn) {
 
 int get_native_btn(mg_gamepad_btn btn) {
   switch (btn) {
-  case MG_GAMEPAD_BUTTON_0:
-    return BTN_0;
-  case MG_GAMEPAD_BUTTON_1:
-    return BTN_1;
-  case MG_GAMEPAD_BUTTON_2:
-    return BTN_2;
-  case MG_GAMEPAD_BUTTON_3:
-    return BTN_3;
-  case MG_GAMEPAD_BUTTON_4:
-    return BTN_4;
-  case MG_GAMEPAD_BUTTON_5:
-    return BTN_5;
-  case MG_GAMEPAD_BUTTON_6:
-    return BTN_6;
-  case MG_GAMEPAD_BUTTON_7:
-    return BTN_7;
-  case MG_GAMEPAD_BUTTON_8:
-    return BTN_8;
-  case MG_GAMEPAD_BUTTON_9:
-    return BTN_9;
-  case MG_GAMEPAD_BUTTON_JOYSTICK:
-    return BTN_JOYSTICK;
-  case MG_GAMEPAD_BUTTON_THUMB:
-    return BTN_THUMB;
-  case MG_GAMEPAD_BUTTON_THUMB2:
-    return BTN_THUMB2;
-  case MG_GAMEPAD_BUTTON_TOP:
-    return BTN_TOP;
-  case MG_GAMEPAD_BUTTON_TOP2:
-    return BTN_TOP2;
-  case MG_GAMEPAD_BUTTON_PINKIE:
-    return BTN_PINKIE;
-  case MG_GAMEPAD_BUTTON_BASE:
-    return BTN_BASE;
-  case MG_GAMEPAD_BUTTON_BASE2:
-    return BTN_BASE2;
-  case MG_GAMEPAD_BUTTON_BASE3:
-    return BTN_BASE3;
-  case MG_GAMEPAD_BUTTON_BASE4:
-    return BTN_BASE4;
-  case MG_GAMEPAD_BUTTON_BASE5:
-    return BTN_BASE5;
-  case MG_GAMEPAD_BUTTON_BASE6:
-    return BTN_BASE6;
-  case MG_GAMEPAD_BUTTON_DEAD:
-    return BTN_DEAD;
-  case MG_GAMEPAD_BUTTON_10:
+  case MG_GAMEPAD_BUTTON_MAX:
+  case MG_GAMEPAD_BUTTON_UNKNOWN:
+    return BTN_MISC;
+  case MG_GAMEPAD_BUTTON_SOUTH:
     return BTN_SOUTH;
-  case MG_GAMEPAD_BUTTON_13:
-    return BTN_EAST;
-  case MG_GAMEPAD_BUTTON_C:
-    return BTN_C;
-  case MG_GAMEPAD_BUTTON_11:
-    return BTN_NORTH;
-  case MG_GAMEPAD_BUTTON_12:
+  case MG_GAMEPAD_BUTTON_WEST:
     return BTN_WEST;
-  case MG_GAMEPAD_BUTTON_Z:
-    return BTN_Z;
-  case MG_GAMEPAD_BUTTON_TL:
-    return BTN_TL;
-  case MG_GAMEPAD_BUTTON_TR:
-    return BTN_TR;
-  case MG_GAMEPAD_BUTTON_TL2:
-    return BTN_TL2;
-  case MG_GAMEPAD_BUTTON_TR2:
-    return BTN_TR2;
-  case MG_GAMEPAD_BUTTON_SELECT:
-    return BTN_SELECT;
+  case MG_GAMEPAD_BUTTON_NORTH:
+    return BTN_NORTH;
+  case MG_GAMEPAD_BUTTON_EAST:
+    return BTN_EAST;
+  case MG_GAMEPAD_BUTTON_BACK:
+    return BTN_BACK;
+  case MG_GAMEPAD_BUTTON_GUIDE:
+    return BTN_MODE;
   case MG_GAMEPAD_BUTTON_START:
     return BTN_START;
-  case MG_GAMEPAD_BUTTON_MODE:
-    return BTN_MODE;
-  case MG_GAMEPAD_BUTTON_THUMBL:
+  case MG_GAMEPAD_BUTTON_LEFT_STICK:
     return BTN_THUMBL;
-  case MG_GAMEPAD_BUTTON_THUMBR:
+  case MG_GAMEPAD_BUTTON_RIGHT_STICK:
     return BTN_THUMBR;
-  case MG_GAMEPAD_BUTTON_DIGI:
-    return BTN_DIGI;
-  case MG_GAMEPAD_BUTTON_UNKNOWN:
+  case MG_GAMEPAD_BUTTON_LEFT_SHOULDER:
+    return BTN_TL;
+  case MG_GAMEPAD_BUTTON_RIGHT_SHOULDER:
+    return BTN_TR;
+  case MG_GAMEPAD_BUTTON_TOUCHPAD:
+    return BTN_TOUCH;
+  case MG_GAMEPAD_BUTTON_MISC1:
+    return BTN_TRIGGER_HAPPY1;
+  case MG_GAMEPAD_BUTTON_MISC2:
+    return BTN_TRIGGER_HAPPY2;
+  case MG_GAMEPAD_BUTTON_MISC3:
+    return BTN_TRIGGER_HAPPY3;
+  case MG_GAMEPAD_BUTTON_MISC4:
+    return BTN_TRIGGER_HAPPY4;
+  case MG_GAMEPAD_BUTTON_MISC5:
+    return BTN_TRIGGER_HAPPY5;
+  case MG_GAMEPAD_BUTTON_MISC6:
+    return BTN_TRIGGER_HAPPY6;
+  default:
     return BTN_MISC;
   }
 };

--- a/src/linux/linux.c
+++ b/src/linux/linux.c
@@ -49,7 +49,7 @@ mg_gamepads *mg_gamepads_get() {
     size_t deadzones_len = 0;
     struct mg_gamepad_t gamepad;
     // go through any buttons a gamepad would have
-    for (int i = BTN_MISC; i <= BTN_GEAR_UP; i++) {
+    for (int i = BTN_MISC; i <= BTN_TRIGGER_HAPPY6; i++) {
       // if this device has one...
       if (libevdev_has_event_code(dev, EV_KEY, i)) {
         // On the first run, we're gonna save this device, and signify to the


### PR DESCRIPTION
Copy SDL's [SDL_GamepadButton](https://wiki.libsdl.org/SDL3/SDL_GamepadButton), ignoring the problem that libevdev has of swapping face buttons (assuming we're gonna do #8 anyways). We also add support for Xbox paddles in the process.