### PR TITLE
minify minigamepad

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 Minimalist, cross-platform, C99 library for dealing with gamepads. Currently not heavily battle-tested and is only supported for Linux.
 
 ```c
-#include <minigamepad.h>
+#include "minigamepad.h"
 
 int main() {
   mg_gamepads *joysticks = mg_gamepads_get();
 
-  size_t joystick_num = mg_gamepads_num(joysticks);
+  size_t joystick_num = joysticks->num;
 
   for (int i = 0; i < joystick_num; i++) {
-    mg_gamepad *gamepad = mg_gamepads_at(joysticks, i);
+    mg_gamepad *gamepad = joysticks->list[i];
     printf("%s\n", mg_gamepad_get_name(gamepad));
   }
 

--- a/examples/gamepadlist.c
+++ b/examples/gamepadlist.c
@@ -4,10 +4,10 @@
 int main() {
   mg_gamepads *joysticks = mg_gamepads_get();
 
-  size_t joystick_num = mg_gamepads_num(joysticks);
+  size_t joystick_num = joysticks->num;
 
   for (int i = 0; i < joystick_num; i++) {
-    mg_gamepad *gamepad = mg_gamepads_at(joysticks, i);
+    mg_gamepad *gamepad = joysticks->list[i];
     printf("%s\n", mg_gamepad_get_name(gamepad));
   }
 

--- a/examples/gamepadquery.c
+++ b/examples/gamepadquery.c
@@ -4,7 +4,7 @@
 int main() {
   mg_gamepads *gamepads = mg_gamepads_get();
 
-  size_t gamepad_num = mg_gamepads_num(gamepads);
+  size_t num = gamepads->num;
 
   int idx = 0;
 
@@ -12,34 +12,28 @@ int main() {
   printf("\e[1;1H\e[2J");
 
   for (;;) {
-    if (idx >= gamepad_num) {
+    if (idx >= num) {
       idx--;
       continue;
     }
-    mg_gamepad *gamepad = mg_gamepads_at(gamepads, idx);
-
+    mg_gamepad *gamepad = gamepads->list[idx];
     mg_gamepad_update(gamepad);
 
     printf("     Gamepad: %-25s\n", mg_gamepad_get_name(gamepad));
-    size_t gamepad_button_num = mg_gamepad_btns_num(gamepad);
+    size_t gamepad_button_num = gamepad->button_num;
     for (int i = 0; i < gamepad_button_num; i++) {
-      mg_gamepad_btn gamepad_btn = mg_gamepad_btns_at(gamepad, i);
-      if (gamepad_btn == MG_GAMEPAD_BUTTON_UNKNOWN) {
-        continue;
-      }
-      printf("     %25s:\t", mg_gamepad_btn_get_name(gamepad_btn));
-      int state = mg_gamepad_get_button_status(gamepad, gamepad_btn);
-      printf("     %-25d\n", state);
+      mg_gamepad_btn btn = gamepad->buttons[i].key;
+
+      printf("     %25s:\t", mg_gamepad_btn_get_name(btn));
+      printf("     %-25d\n", gamepad->buttons[i].value);
     }
 
-    size_t axis_num = mg_gamepad_get_axis_num(gamepad);
+    size_t axis_num = gamepad->axis_num;
     for (int i = 0; i < axis_num; i++) {
-
-      mg_gamepad_axis axis = mg_gamepad_axis_at(gamepad, i);
+      mg_gamepad_axis axis = gamepad->axises[i].key;
 
       printf("     %25s:\t", mg_gamepad_axis_get_name(axis));
-      int state = mg_gamepad_get_axis_status(gamepad, axis);
-      printf("     %-25d\n", state);
+      printf("     %-25d\n", gamepad->axises[i].value);
     }
     printf("\33[%d;%dH", 0, 0);
   }

--- a/include/minigamepad.h
+++ b/include/minigamepad.h
@@ -3,13 +3,11 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct mg_gamepad_t mg_gamepad;
-typedef struct mg_gamepads_t mg_gamepads;
 
 /// A button on a gamepad
 typedef enum {
@@ -83,6 +81,38 @@ typedef enum {
 #define MAX_BUTTONS MG_GAMEPAD_BUTTON_MAX
 #define MAX_AXISES MG_GAMEPAD_AXIS_MAX
 
+/// Internal context of the gamepad, i.e. implementation details.
+struct mg_gamepad_context_t;
+
+typedef struct mg_gamepad_t {
+  // Internal context for platform dependent items.
+  struct mg_gamepad_context_t *ctx;
+  // Map of buttons that the controller has
+  struct {
+    mg_gamepad_btn key;
+    int16_t value;
+  } buttons[MAX_BUTTONS];
+  // The number of buttons on the controller.
+  size_t button_num;
+  // Map of axises that the controller has, + their deadzones
+  // By default, the deadzones are 5000 for any axis that isn't the d-pad; you
+  // are strongly encouraged to make this customizable in any program you make
+  // with this.
+  struct {
+    mg_gamepad_axis key;
+    int16_t value;
+    int16_t deadzone;
+  } axises[MAX_AXISES];
+  // The number of axises on the controller.
+  size_t axis_num;
+} mg_gamepad;
+
+/// A list of gamepads recognized by the system.
+typedef struct mg_gamepads_t {
+  struct mg_gamepad_t *list[16];
+  size_t num;
+} mg_gamepads;
+
 /// Update the gamepad's internal structure.
 /// This needs to be called before any gamepad buttons/axises are checked if you
 /// want the correct values.
@@ -90,41 +120,16 @@ void mg_gamepad_update(mg_gamepad *gamepad);
 
 /// Get the gamepads currently connected to the system.
 mg_gamepads *mg_gamepads_get();
-/// Get the number of gamepads attached to the system.
-size_t mg_gamepads_num(mg_gamepads *gamepads);
-/// Get the game pad at the given index.
-mg_gamepad *mg_gamepads_at(mg_gamepads *mj, size_t idx);
 /// Free the struct acquired by `mg_gamepads_get`.
 void mg_gamepads_free(mg_gamepads *gamepads);
 
 /// Get the gamepad's name.
 const char *mg_gamepad_get_name(mg_gamepad *gamepad);
-/// Get the current status of the button.
-int mg_gamepad_get_button_status(mg_gamepad *gamepad, mg_gamepad_btn btn);
 
-/// Get the number of buttons on the given gamepad
-size_t mg_gamepad_btns_num(mg_gamepad *gamepad);
-/// Get the button at the given index.
-mg_gamepad_btn mg_gamepad_btns_at(mg_gamepad *gamepad, size_t idx);
 /// Get the name of a gamepad button.
 const char *mg_gamepad_btn_get_name(mg_gamepad_btn);
-
-/// Get the number of axises on a gamepad
-size_t mg_gamepad_get_axis_num(mg_gamepad *gamepad);
-/// Get the axis at the given index.
-mg_gamepad_axis mg_gamepad_axis_at(mg_gamepad *gamepad, size_t idx);
-/// Get the value of the nth axis on this gamepad
-int mg_gamepad_get_axis_status(mg_gamepad *gamepad, size_t idx);
 /// Get the name of a gamepad axis.
 const char *mg_gamepad_axis_get_name(mg_gamepad_axis axis);
-
-/// Get the deadzone set for this controller axis
-/// By default, this is 5000 for any axis that isn't a hat; you are strongly
-/// encouraged to make this customizable in any program you make with this.
-size_t mg_gamepad_get_axis_deadzone(mg_gamepad *gamepad, size_t axis);
-/// Set the deadzone for this controller axis
-void mg_gamepad_set_axis_deadzone(mg_gamepad *gamepad, size_t axis,
-                                  size_t deadzone);
 
 #ifdef __cplusplus
 }

--- a/src/linux/linux.c
+++ b/src/linux/linux.c
@@ -20,7 +20,7 @@ mg_gamepads *mg_gamepads_get() {
     return 0;
   }
 
-  struct mg_gamepad_t *gamepads_list = NULL;
+  struct mg_gamepad_t *list = NULL;
   size_t gamepad_len = 0;
 
   struct mg_gamepads_t *gamepads = malloc(sizeof(struct mg_gamepads_t));
@@ -41,13 +41,21 @@ mg_gamepads *mg_gamepads_get() {
     };
 
     bool good = false;
-    mg_gamepad_btn_map_type buttons[MAX_BUTTONS];
-    mg_gamepad_axis_map_type axises[MAX_AXISES];
-    mg_gamepad_axis_map_type deadzones[MAX_AXISES];
-    size_t button_len = 0;
-    size_t axis_len = 0;
+    struct {
+      mg_gamepad_btn key;
+      int16_t value;
+    } buttons[MAX_BUTTONS];
+    struct {
+      mg_gamepad_axis key;
+      int16_t value;
+      int16_t deadzone;
+    } axises[MAX_AXISES];
+    size_t button_num = 0;
+    size_t axis_num = 0;
     size_t deadzones_len = 0;
-    struct mg_gamepad_t gamepad;
+    struct mg_gamepad_t gamepad = {};
+    gamepad.ctx = malloc(sizeof(struct mg_gamepad_context_t));
+
     // go through any buttons a gamepad would have
     for (int i = BTN_MISC; i <= BTN_TRIGGER_HAPPY6; i++) {
       // if this device has one...
@@ -55,22 +63,20 @@ mg_gamepads *mg_gamepads_get() {
         // On the first run, we're gonna save this device, and signify to the
         // below code that we have something.
         if (!good) {
-          gamepad.dev = dev;
+          gamepad.ctx->dev = dev;
           good = true;
         }
         // and put the gamepad button we have down.
-        gamepad.buttons[button_len] = (mg_gamepad_btn_map_type){
-            .key = get_gamepad_btn(i),
-            .value = 0,
-        };
-        button_len += 1;
+        gamepad.buttons[button_num].key = get_gamepad_btn(i);
+        gamepad.buttons[button_num].value = 0;
+        button_num += 1;
       }
     }
     // go through any axises a gamepad would have
     for (int i = ABS_X; i <= ABS_MAX; i++) {
       if (libevdev_has_event_code(dev, EV_ABS, i)) {
         if (!good) {
-          gamepad.dev = dev;
+          gamepad.ctx->dev = dev;
           good = true;
         }
 
@@ -93,20 +99,21 @@ mg_gamepads *mg_gamepads_get() {
           break;
         }
 
-        gamepad.axises[axis_len] =
-            (mg_gamepad_axis_map_type){.key = get_gamepad_axis(i), .value = 0};
+        gamepad.axises[axis_num].key = get_gamepad_axis(i);
+        gamepad.axises[axis_num].value = 0;
+        gamepad.axises[axis_num].deadzone = deadzone;
 
-        gamepad.deadzones[axis_len] = (mg_gamepad_axis_map_type){
-            .key = get_gamepad_axis(i), .value = deadzone};
-
-        axis_len += 1;
+        axis_num += 1;
       }
     }
 
     if (good) {
-      gamepad.button_len = button_len;
-      gamepad.axis_len = axis_len;
-      gamepads->gamepads_list[gamepad_len] = gamepad;
+      gamepad.button_num = button_num;
+      gamepad.axis_num = axis_num;
+
+      gamepads->list[gamepad_len] = malloc(sizeof(gamepad));
+      *gamepads->list[gamepad_len] = gamepad;
+
       gamepad_len += 1;
     } else {
       if (dev != NULL) {
@@ -115,30 +122,25 @@ mg_gamepads *mg_gamepads_get() {
     }
   }
 
-  gamepads->gamepads_list_len = gamepad_len;
+  gamepads->num = gamepad_len;
 
   return gamepads;
 };
 
-size_t mg_gamepads_num(mg_gamepads *gamepads) {
-  return gamepads->gamepads_list_len;
-};
-mg_gamepad *mg_gamepads_at(mg_gamepads *gamepads, size_t idx) {
-  return &gamepads->gamepads_list[idx];
-};
+size_t mg_gamepads_num(mg_gamepads *gamepads) { return gamepads->num; };
 
 void mg_gamepads_free(mg_gamepads *gamepads) { free(gamepads); };
 
 const char *mg_gamepad_get_name(mg_gamepad *gamepad) {
-  return libevdev_get_name(gamepad->dev);
+  return libevdev_get_name(gamepad->ctx->dev);
 }
 
 void mg_gamepad_update(mg_gamepad *gamepad) {
   struct input_event ev;
-  int pending = libevdev_has_event_pending(gamepad->dev);
+  int pending = libevdev_has_event_pending(gamepad->ctx->dev);
   if (pending) {
-    int rc =
-        libevdev_next_event(gamepad->dev, LIBEVDEV_READ_FLAG_BLOCKING, &ev);
+    int rc = libevdev_next_event(gamepad->ctx->dev, LIBEVDEV_READ_FLAG_BLOCKING,
+                                 &ev);
     if (rc) {
       return;
     }
@@ -146,16 +148,11 @@ void mg_gamepad_update(mg_gamepad *gamepad) {
     return;
   }
 
-  // // take this opprutunity to reset every axis
-  // for (int i = 0; i < gamepad->axis_len; i++) {
-  //   gamepad->axises[i].value = 0;
-  // }
-
   switch (ev.type) {
   case EV_KEY: {
     mg_gamepad_btn btn = get_gamepad_btn(ev.code);
 
-    for (int i = 0; i <= gamepad->button_len; i++) {
+    for (int i = 0; i <= gamepad->button_num; i++) {
       if (gamepad->buttons[i].key == btn) {
         gamepad->buttons[i].value = ev.value;
       }
@@ -165,18 +162,15 @@ void mg_gamepad_update(mg_gamepad *gamepad) {
   case EV_ABS: {
     mg_gamepad_axis axis = get_gamepad_axis(ev.code);
 
-    for (int i = 0; i <= gamepad->axis_len; i++) {
+    for (int i = 0; i <= gamepad->axis_num; i++) {
       if (gamepad->axises[i].key == axis) {
-        int deadzone = gamepad->deadzones[i].value;
+        int deadzone = gamepad->axises[i].deadzone;
         int event_val = 0;
         if (abs(ev.value) >= deadzone) {
           event_val = ev.value;
         }
-        mg_gamepad_axis_map_type value = {
-            .key = axis,
-            .value = event_val,
-        };
-        gamepad->axises[i] = value;
+        gamepad->axises[i].key = axis;
+        gamepad->axises[i].value = event_val;
       }
     }
     break;
@@ -185,51 +179,3 @@ void mg_gamepad_update(mg_gamepad *gamepad) {
     break;
   }
 }
-
-int mg_gamepad_get_button_status(mg_gamepad *gamepad, mg_gamepad_btn btn) {
-  for (int i = 0; i < gamepad->button_len; i++) {
-    if (gamepad->buttons[i].key == btn) {
-      return gamepad->buttons[i].value;
-    }
-  }
-  return -1;
-}
-
-size_t mg_gamepad_btns_num(mg_gamepad *gamepad) { return gamepad->button_len; };
-mg_gamepad_btn mg_gamepad_btns_at(mg_gamepad *gamepad, size_t idx) {
-  return gamepad->buttons[idx].key;
-};
-
-size_t mg_gamepad_get_axis_num(mg_gamepad *gamepad) {
-  return gamepad->axis_len;
-}
-
-int mg_gamepad_get_axis_status(mg_gamepad *gamepad, size_t axis) {
-  for (int i = 0; i < gamepad->axis_len; i++) {
-    if (gamepad->axises[i].key == axis) {
-      return gamepad->axises[i].value;
-    }
-  }
-  return -1;
-}
-
-mg_gamepad_axis mg_gamepad_axis_at(mg_gamepad *gamepad, size_t idx) {
-  return gamepad->axises[idx].key;
-}
-
-size_t mg_gamepad_get_axis_deadzone(mg_gamepad *gamepad, size_t axis) {
-  for (int i = 0; i < gamepad->axis_len; i++) {
-    if (gamepad->deadzones[i].key == axis) {
-      return gamepad->deadzones[i].value;
-    }
-  }
-  return -1;
-};
-void mg_gamepad_set_axis_deadzone(mg_gamepad *gamepad, size_t axis,
-                                  size_t deadzone) {
-  for (int i = 0; i < gamepad->axis_len; i++) {
-    if (gamepad->deadzones[i].key == axis) {
-      gamepad->deadzones[i].value = deadzone;
-    }
-  }
-};

--- a/src/linux/linux.h
+++ b/src/linux/linux.h
@@ -5,28 +5,9 @@
 #ifndef __minigamepad_LINUX
 #define __minigamepad_LINUX
 
-typedef struct {
-  mg_gamepad_btn key;
-  int16_t value;
-} mg_gamepad_btn_map_type;
-
-typedef struct {
-  mg_gamepad_axis key;
-  int16_t value;
-} mg_gamepad_axis_map_type;
-
-struct mg_gamepad_t {
+struct mg_gamepad_context_t {
   struct libevdev *dev;
-  mg_gamepad_btn_map_type buttons[MAX_BUTTONS];
-  mg_gamepad_axis_map_type axises[MAX_AXISES];
-  mg_gamepad_axis_map_type deadzones[MAX_AXISES];
-  size_t button_len;
-  size_t axis_len;
-  // deadzone_len is the same as axis_len
-};
-struct mg_gamepads_t {
-  struct mg_gamepad_t gamepads_list[16];
-  size_t gamepads_list_len;
+  struct input_event input_event;
 };
 
 mg_gamepad_btn get_gamepad_btn(int btn);


### PR DESCRIPTION
- Makes `mg_gamepads` and `mg_gamepad` no longer transparent. Instead, `mg_gamepad_context_t` to be a transparent struct that holds any implementation details.
- Lots of getter/setter functions are removed now that things are just exposed as fields.