### PR TITLE
Fix the dead-loop when calling `mg_gamepads_free`

### DIFF
--- a/minigamepad.h
+++ b/minigamepad.h
@@ -882,12 +882,15 @@ mg_bool mg_gamepads_check_queued_event(mg_gamepads* gamepads, mg_event* event) {
 
 void mg_gamepads_free(mg_gamepads* gamepads) {
     mg_gamepad* cur;
+    mg_gamepad* prev;
     MG_ASSERT(gamepads != NULL);
 
     mg_gamepads_free_platform(gamepads);
 
-    for (cur = gamepads->list.cur; cur != NULL; cur = cur->prev) {
+    for (cur = gamepads->list.cur; cur != NULL;) {
+        prev = cur->prev;
         mg_gamepad_release(gamepads, cur);
+        cur = prev;
     }
     MG_MEMSET(gamepads, 0, sizeof(mg_gamepads));
 }


### PR DESCRIPTION
Fix #43, #32 - the dead-loop in `mg_gamepads_free`.