### PR TITLE
change axis from 8 to 6

### DIFF
--- a/minigamepad.h
+++ b/minigamepad.h
@@ -2738,11 +2738,11 @@ mg_bool parseMapping(mg_mapping* mapping, const char* string) {
 
     len = (sizeof(fields) / sizeof(mg_field));
 
-    for (i = 1; i < len - 8; i++) {
+    for (i = 1; i < len - 6; i++) {
         fields[i].element = &mapping->buttons[fields[i].val];
     }
 
-    for (i = len - 8; i < len; i++) {
+    for (i = len - 6; i < len; i++) {
         fields[i].element = &mapping->axes[fields[i].val];
     }
 


### PR DESCRIPTION
#### The previous was doing `-8` to separate axis from buttons, but there are only 6. this causes an out of range error on zig:

```
thread 327126 panic: index 15 out of bounds for type 'mg_element[6]' (aka 'struct mg_element[6]')
minigamepad.h:2746:30: 0x10f893a in parseMapping
        fields[i].element = &mapping->axes[fields[i].val];
```
```cpp
        { "lefttrigger", 11,   MG_BUTTON_LEFT_TRIGGER , NULL},
        { "righttrigger", 12,  MG_BUTTON_RIGHT_TRIGGER , NULL },

        { "lefttrigger", 11,   MG_AXIS_LEFT_TRIGGER, NULL},
        { "righttrigger", 12,  MG_AXIS_RIGHT_TRIGGER, NULL },
        { "leftx",  5,       MG_AXIS_LEFT_X, NULL },
        { "lefty",  5,       MG_AXIS_LEFT_Y, NULL } ,
        { "rightx", 6,       MG_AXIS_RIGHT_X, NULL},
        { "righty", 6,        MG_AXIS_RIGHT_Y, NULL }
    };
```