### PR TITLE
fix: out-of-bounds write on mapping->axes in parseMapping

### DIFF
--- a/minigamepad.h
+++ b/minigamepad.h
@@ -2738,11 +2738,11 @@ mg_bool parseMapping(mg_mapping* mapping, const char* string) {
 
     len = (sizeof(fields) / sizeof(mg_field));
 
-    for (i = 1; i < len - 8; i++) {
+    for (i = 1; i < len - 6; i++) {
         fields[i].element = &mapping->buttons[fields[i].val];
     }
 
-    for (i = len - 8; i < len; i++) {
+    for (i = len - 6; i < len; i++) {
         fields[i].element = &mapping->axes[fields[i].val];
     }
 


### PR DESCRIPTION
The `fields` array has 17 button entries + 6 axis entries = 23 total (indices 1–23, index 0 is platform). But the split point was `len - 8`, which routed the last 2 **button** entries (indices 16–17, with values `MG_BUTTON_LEFT_TRIGGER=15` and `MG_BUTTON_RIGHT_TRIGGER=16`) into the axis loop — and `mapping->axes` only has 6 elements.

**Fix:** Change `len - 8` to `len - 6` so the 6 axis entries (indices 18–23) are correctly routed to `mapping->axes`.

Detected by UBSan:
```
minigamepad.h:2746:30: runtime error: index 15 out of bounds for type 'mg_element[6]'
```

Closes #47