### PR TITLE
fix: fix OOB access in `parseMapping`

### DIFF
--- a/minigamepad.h
+++ b/minigamepad.h
@@ -2704,9 +2704,6 @@ typedef struct mg_field {
 } mg_field;
 
 
-#define BUTTON_FIELDS_START 1
-#define AXIS_FIELDS_START 18
-
 MG_API mg_bool parseMapping(mg_mapping* mapping, const char* string);
 mg_bool parseMapping(mg_mapping* mapping, const char* string) {
     const char* substr = string;
@@ -2714,7 +2711,7 @@ mg_bool parseMapping(mg_mapping* mapping, const char* string) {
     mg_field fields[] = {
         { "platform", 8,     0, NULL },
 
-        [BUTTON_FIELDS_START] = { "a", 1,             MG_BUTTON_SOUTH , NULL},
+        { "a", 1,             MG_BUTTON_SOUTH , NULL},
         { "b", 1,           MG_BUTTON_EAST , NULL},
         { "x", 1,            MG_BUTTON_WEST , NULL},
         { "y", 1,            MG_BUTTON_NORTH , NULL},
@@ -2732,7 +2729,7 @@ mg_bool parseMapping(mg_mapping* mapping, const char* string) {
         { "lefttrigger", 11,   MG_BUTTON_LEFT_TRIGGER , NULL},
         { "righttrigger", 12,  MG_BUTTON_RIGHT_TRIGGER , NULL },
 
-        [AXIS_FIELDS_START] = { "lefttrigger", 11,   MG_AXIS_LEFT_TRIGGER, NULL},
+        { "lefttrigger", 11,   MG_AXIS_LEFT_TRIGGER, NULL},
         { "righttrigger", 12,  MG_AXIS_RIGHT_TRIGGER, NULL },
         { "leftx",  5,       MG_AXIS_LEFT_X, NULL },
         { "lefty",  5,       MG_AXIS_LEFT_Y, NULL } ,
@@ -2740,13 +2737,16 @@ mg_bool parseMapping(mg_mapping* mapping, const char* string) {
         { "righty", 6,        MG_AXIS_RIGHT_Y, NULL }
     };
 
+    static const mg_size_t button_fields_start = 1;
+    static const mg_size_t axis_fields_count = 6;
     len = (sizeof(fields) / sizeof(mg_field));
+    mg_size_t axis_start = len - axis_fields_count;
 
-    for (i = BUTTON_FIELDS_START; i < AXIS_FIELDS_START; i++) {
+    for (i = button_fields_start; i < axis_start; i++) {
         fields[i].element = &mapping->buttons[fields[i].val];
     }
 
-    for (i = AXIS_FIELDS_START; i < len; i++) {
+    for (i = axis_start; i < len; i++) {
         fields[i].element = &mapping->axes[fields[i].val];
     }
 

--- a/minigamepad.h
+++ b/minigamepad.h
@@ -2704,13 +2704,17 @@ typedef struct mg_field {
 } mg_field;
 
 
+#define BUTTON_FIELDS_START 1
+#define AXIS_FIELDS_START 18
+
 MG_API mg_bool parseMapping(mg_mapping* mapping, const char* string);
 mg_bool parseMapping(mg_mapping* mapping, const char* string) {
     const char* substr = string;
     mg_size_t i, length, len;
     mg_field fields[] = {
         { "platform", 8,     0, NULL },
-        { "a", 1,             MG_BUTTON_SOUTH , NULL},
+
+        [BUTTON_FIELDS_START] = { "a", 1,             MG_BUTTON_SOUTH , NULL},
         { "b", 1,           MG_BUTTON_EAST , NULL},
         { "x", 1,            MG_BUTTON_WEST , NULL},
         { "y", 1,            MG_BUTTON_NORTH , NULL},
@@ -2728,7 +2732,7 @@ mg_bool parseMapping(mg_mapping* mapping, const char* string) {
         { "lefttrigger", 11,   MG_BUTTON_LEFT_TRIGGER , NULL},
         { "righttrigger", 12,  MG_BUTTON_RIGHT_TRIGGER , NULL },
 
-        { "lefttrigger", 11,   MG_AXIS_LEFT_TRIGGER, NULL},
+        [AXIS_FIELDS_START] = { "lefttrigger", 11,   MG_AXIS_LEFT_TRIGGER, NULL},
         { "righttrigger", 12,  MG_AXIS_RIGHT_TRIGGER, NULL },
         { "leftx",  5,       MG_AXIS_LEFT_X, NULL },
         { "lefty",  5,       MG_AXIS_LEFT_Y, NULL } ,
@@ -2738,11 +2742,11 @@ mg_bool parseMapping(mg_mapping* mapping, const char* string) {
 
     len = (sizeof(fields) / sizeof(mg_field));
 
-    for (i = 1; i < len - 8; i++) {
+    for (i = BUTTON_FIELDS_START; i < AXIS_FIELDS_START; i++) {
         fields[i].element = &mapping->buttons[fields[i].val];
     }
 
-    for (i = len - 8; i < len; i++) {
+    for (i = AXIS_FIELDS_START; i < len; i++) {
         fields[i].element = &mapping->axes[fields[i].val];
     }
 


### PR DESCRIPTION
Note: Supercedes #48.  #48 was assisted by AI, and this patch was written without help from AI.

As I said in #49, there's probably a more robust solution that refactors the code to make these bugs less likely, but this is breaking using Raylib with Zig today, so I think we can land a temporary solution before doing a more robust fix.

Fixes #49
